### PR TITLE
feat: 채팅/게시물 타입 정의 및 컴포넌트 분리

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,2 @@
+Always respond in Korean.
+항상 한국어로 답변.

--- a/docs/devNote.txt
+++ b/docs/devNote.txt
@@ -70,3 +70,219 @@ const [todos, setTodos] = useState<Todo[]>({
 - navigation.navigate('ScreenName', params)
 -- navigation.navigate('Login', id) // Login 페이지로 id를 들고 감
 - navigation.goBack() // 뒤로 가기
+
+
+
+----------------------------------------------------
+
+1. 이 화면을 기능 단위로 쪼개서 이해하기
+만들고 싶은 메인 화면의 기능을 먼저 나눠보면:
+
+채팅/게시판 아이템 리스트 (FlatList + type에 따라 다른 UI)
+
+하단 입력 영역 (TextInput + 전송 버튼)
+
+타입 토글 (채팅 ↔ 게시판 모드 전환 버튼)
+
+롱프레스 → 모달 (onLongPress로 모달 열기 → “게시판으로 변경” 클릭)
+
+“채팅 → 게시판으로 변경” 시, 배열 안의 한 아이템의 type과 필드 구조를 바꾸는 로직
+
+이 5가지를 각각 독립된 문제로 보고, 하나씩 해결하면서 합치는 식으로 접근하면 훨씬 덜 복잡해져요.
+
+2. TypeScript 처음 쓸 때 꼭 알아야 할 것
+TS는 “런타임 동작을 바꾸는 게 아니라, 컴파일 타임에 형검사만 추가된 JS”라고 생각하면 편해요.
+
+이 프로젝트에서 먼저 쓸 TS 개념은 딱 3개만 잡고 시작해도 충분해요:
+
+type / interface로 모델 정의
+
+예:
+
+ts
+type MessageType = 'chat' | 'post';
+interface ChatMessage { id: string; type: 'chat'; text: string; }
+interface BoardPost { id: string; type: 'post'; title: string; content: string; }
+type ChatBoardItem = ChatMessage | BoardPost; // 유니온 타입
+목적: items 배열에 “chat인지 post인지”를 타입 레벨에서 강제.
+
+컴포넌트 Props 타입
+
+예:
+
+ts
+interface ChatMessageItemProps { item: ChatMessage; }
+const ChatMessageItem: React.FC<ChatMessageItemProps> = ({ item }) => { ... };
+목적: item에 .title 같은 필드 잘못 쓰면 컴파일 단계에서 잡게.
+
+useState에 제네릭 타입 지정
+
+예:
+
+ts
+const [items, setItems] = useState<ChatBoardItem[]>([]);
+목적: setItems([...items, "문자열"]) 같은 실수를 미리 막기.
+​
+
+이 3가지를 이 화면에서 직접 써보는 게 TypeScript 입문이라고 생각하면 딱 좋아요.
+
+3. 구현 순서 (진짜 작업 순서 느낌으로)
+1단계: 데이터 모델만 먼저 설계
+지금 코드 수정 안 하고, types/chatBoard.types.ts 하나 만들어서
+ChatMessage, BoardPost, ChatBoardItem 타입만 우선 정의해봐.
+
+이때 “롱프레스 후 게시판으로 변경”을 고려해서 구조를 설계하는 게 포인트:
+
+
+리스트에는 두 종류의 아이템이 섞여 있음
+
+채팅 메시지
+
+게시판 글
+
+둘 다 공통으로 가지는 정보
+
+id: 고유 식별자
+
+type: 'chat' or 'post'
+
+createdAt: 생성 시각
+
+채팅만 가지는 정보
+
+text: 한 줄 메시지
+
+isMe: 내가 쓴 메시지인지 여부 (지금은 항상 true지만 구조는 남김)
+
+게시판만 가지는 정보
+
+title: 제목 (채팅 → 게시판 변경 시, text가 여기로 옮겨짐)
+
+content: 상세 내용
+
+likes, commentsCount: 숫자들
+
+
+공통 필드: id, type, createdAt
+
+채팅에서 게시판으로 바꿀 때:
+
+채팅의 text → 게시판의 title로 옮길 거지?
+
+게시판의 content는 일단 빈 문자열 또는 기본 문구
+
+이걸 미리 상상하면서 필드를 잡는 게 중요.
+
+이 단계에서 질문:
+
+“어떤 필드가 chat/post 모두에 필요하고, 어떤 필드는 타입별로만 필요한지?”
+를 스스로 정의해보는 게 설계 연습이야.
+
+2단계: FlatList + 타입 구분 UI (롱프레스, 모달은 아직 X)
+목표: “채팅/게시글이 섞인 리스트” + “하단 입력창”만 먼저.
+
+MainScreen.tsx 파일에서:
+
+useState<ChatBoardItem[]>(초기 더미 데이터) 정의
+
+FlatList<ChatBoardItem> 에 renderItem으로
+
+ts
+if (item.type === 'chat') { /* 채팅용 컴포넌트 */ }
+else { /* 게시판용 컴포넌트 */ }
+형태로 분기만 구현.
+​
+​
+
+이때 아이템 컴포넌트는 아주 심플하게 시작:
+
+ChatMessageItem: 그냥 Text 하나
+
+BoardPostItem: title, content 두 줄
+
+여기까지 되면 “TS 타입 + FlatList + 조건부 렌더링” 조합을 한 번 경험하게 됨.
+
+3단계: 입력 영역 + 타입 토글 (채팅/게시판 작성 기능)
+목표: 화면 아래에서
+
+모드 버튼: “채팅 / 게시글” 토글
+
+TextInput + 전송 버튼 → items 배열에 push
+
+여기서 중요한 포인트:
+
+messageType을 useState<'chat' | 'post'>('chat') 로 관리
+
+handleSend에서:
+
+if messageType === 'chat' 이면 ChatMessage 형태의 객체 생성
+
+else 이면 BoardPost 형태의 객체 생성
+
+둘 다 ChatBoardItem로 통합되는 구조
+
+이 단계에서 TS가 도움 주는 지점:
+
+newItem = { type: 'chat', ... } 를 만들 때, 빠진 필드가 있으면 빨간줄로 알려줌.
+
+JS였다면 런타임에서야 알 실수를 이 단계에서 다 잡음.
+
+4단계: onLongPress + 모달 동작만 먼저 붙이기 (내용 변경 X)
+이제 “채팅을 꾹 눌렀을 때 모달 띄우기”까지만 구현해요.
+
+ChatMessageItem에 onLongPress 추가:
+
+ChatMessageItem의 Props에 onLongPress?: (item: ChatMessage) => void 추가
+
+아이템 View를 TouchableOpacity로 감싸고 onLongPress={() => onLongPress?.(item)}.
+​
+
+MainScreen에서:
+
+const [selectedItem, setSelectedItem] = useState<ChatMessage | null>(null);
+
+const [modalVisible, setModalVisible] = useState(false);
+
+handleLongPress = (item: ChatMessage) => { setSelectedItem(item); setModalVisible(true); }
+
+모달 컴포넌트에 visible={modalVisible}로 연결
+
+이 시점까지는 **“롱프레스 → 모달 열림”**만 확인하면 돼.
+모달 안에 “게시판으로 변경” 버튼은 아직 동작 안 해도 됨.
+
+5단계: “채팅 → 게시판으로 변경” 알고리즘 생각해보기
+이제 핵심 로직:
+
+특정 id를 가진 ChatMessage를 찾아서,
+그 자리에 BoardPost로 형태를 바꿔 끼우는 것.
+
+순서를 머릿속으로 정리해보면:
+
+selectedItem에 있는 ChatMessage 기준으로
+
+setItems(prev => prev.map(item => { ... })) 사용
+
+item.id === selectedItem.id 인 경우:
+
+ChatMessage → BoardPost로 변환:
+
+id, createdAt 그대로
+
+type: 'post'
+
+title: selectedItem.text
+
+content: '' (또는 기본 텍스트)
+
+likes: 0, commentsCount: 0
+
+나머지 아이템은 그대로 반환
+
+이때 TS는 item이 ChatBoardItem이기 때문에,
+
+if (item.type === 'chat') 블록 안에서는 자동으로 ChatMessage로 좁혀주고
+
+'post'로 새 객체를 만들면 BoardPost로 인식하게 돼.
+
+실제 코드 짜기 전에, 이 알고리즘을 JS 느낌으로 먼저 써보고
+그걸 나중에 TS로 옮기는 방식으로 가면 부담이 덜 함.

--- a/src/components/board/BoardPostItem.tsx
+++ b/src/components/board/BoardPostItem.tsx
@@ -6,6 +6,6 @@ import { BoardPost } from "../../types/chatBoard.type";
 
 const BoardPostItem = ({ item }: { item: BoardPost }) => (
     <Text>게시물 제목: {item.title}, 내용: {item.content}</Text>
-)
+);
 
 export default BoardPostItem;

--- a/src/components/board/BoardPostItem.tsx
+++ b/src/components/board/BoardPostItem.tsx
@@ -1,0 +1,11 @@
+// 게시물 아이템 컴포넌트
+
+import React from "react";
+import { Text } from "react-native";
+import { BoardPost } from "../../types/chatBoard.type";
+
+const BoardPostItem = ({ item }: { item: BoardPost }) => (
+    <Text>게시물 제목: {item.title}, 내용: {item.content}</Text>
+)
+
+export default BoardPostItem;

--- a/src/components/chat/ChatMessageItem.tsx
+++ b/src/components/chat/ChatMessageItem.tsx
@@ -6,6 +6,6 @@ import { ChatMessage } from "../../types/chatBoard.type"
 
 const ChatMessageItem = ({ item }: { item: ChatMessage }) => (
     <Text>채팅: {item.text}</Text>
-)
+);
 
 export default ChatMessageItem;

--- a/src/components/chat/ChatMessageItem.tsx
+++ b/src/components/chat/ChatMessageItem.tsx
@@ -1,8 +1,8 @@
 // 채팅 아이템 컴포넌트
 
-import React from "react"
-import { Text } from "react-native"
-import { ChatMessage } from "../../types/chatBoard.type"
+import React from "react";
+import { Text } from "react-native";
+import { ChatMessage } from "../../types/chatBoard.type";
 
 const ChatMessageItem = ({ item }: { item: ChatMessage }) => (
     <Text>채팅: {item.text}</Text>

--- a/src/components/chat/ChatMessageItem.tsx
+++ b/src/components/chat/ChatMessageItem.tsx
@@ -1,0 +1,11 @@
+// 채팅 아이템 컴포넌트
+
+import React from "react"
+import { Text } from "react-native"
+import { ChatMessage } from "../../types/chatBoard.type"
+
+const ChatMessageItem = ({ item }: { item: ChatMessage }) => (
+    <Text>채팅: {item.text}</Text>
+)
+
+export default ChatMessageItem;

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -13,7 +13,7 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 
 const RootNavigator = () => {
     return (
-        // 일단은 Home 부터 시작
+        // 일단은 Main 화면부터 시작
         <Stack.Navigator initialRouteName="Main">
             {/* 아래에 화면 리스트 추가 */}
             <Stack.Screen

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,11 +1,11 @@
 // 전체 네비게이션 구조(Stack/Tab 등)
 import React from 'react';
-import {createNativeStackNavigator} from '@react-navigation/native-stack';
-import HomeScreen from '../screens/HomeScreen';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import MainScreen from '../screens/MainScreen';
 
 // 네비게이션에서 사용할 화면 목록과 파라미터 타입 정의
 export type RootStackParamList = {
-    Home: undefined; // 파라미터 없음
+    Main: undefined; // 파라미터 없음
 }
 
 // Stack 형태의 Navigator 생성 함수
@@ -14,13 +14,13 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 const RootNavigator = () => {
     return (
         // 일단은 Home 부터 시작
-        <Stack.Navigator initialRouteName="Home">
+        <Stack.Navigator initialRouteName="Main">
             {/* 아래에 화면 리스트 추가 */}
             <Stack.Screen
-            name="Home"
-            component={HomeScreen}
-            options={{title: "홈"}}
-            />    
+                name="Main"
+                component={MainScreen}
+                options={{ title: "홈" }}
+            />
         </Stack.Navigator>
     )
 }

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,26 +1,44 @@
 import React, { useEffect, useState } from 'react';
-import { View, Alert, Text, Button, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Alert, Text, Button, StyleSheet, TouchableOpacity, FlatList } from 'react-native';
 import { ChatBoardItem, ChatMessage, BoardPost, MessageType } from '../types/chatBoard.type';
 
+const initItems: ChatBoardItem[] = [
+    {
+        id: '1',
+        userId: '24',
+        type: 'chat',
+        bookMark: false,
+        text: '오늘 할 일을 정리해보자.',
+        createdAt: new Date().toISOString(),
+    },
+    {
+        id: '2',
+        userId: '22',
+        bookMark: false,
+        type: 'post',
+        title: '📌 오늘의 TODO',
+        content: '- 타입 정의하기\n- 메인 화면 UI 잡기',
+        createdAt: new Date().toISOString(),
+    },
+]
+
 const MainScreen = () => {
-    const [count, setCount] = useState<number>(0);
-
-    const handleCount = () => {
-        setCount(count + 1);
-    }
-
-    useEffect(() => {
-        if (count >= 10) {
-            Alert.alert("ㅎㅇ");
-        }
-    }, [count]);
+    const [items, setItems] = useState<ChatBoardItem[]>(initItems);
+    const [messageType, setMessageType] = useState<MessageType>('chat');
+    const [inputText, setInputText] = useState('');
 
     return (
         <View style={styles.container}>
-            <Text>맴매 맞을 횟수: {count}</Text>
-            <TouchableOpacity onPress={handleCount} style={styles.button}>
-                <Text>+</Text>
-            </TouchableOpacity>
+            <FlatList<ChatBoardItem> // 이 리스트는 ChatBoardItem 배열을 렌더링하는 컴포넌트 명시
+                data={items} // 리스트에 보일 데이터 배열
+                keyExtractor={item => item.id} // items 중 하나의 아이템의 고유 key를 뽑는 함수(item의 id를 key로 쓰겠다.)
+                renderItem={({item}) => {
+                    if(item.type == 'chat') {
+                        return <Text>채팅: {item.text}</Text>;
+                    }
+                    return <Text>게시글: {item.title}</Text>;
+                }}
+            />
         </View>
     )
 }
@@ -30,16 +48,6 @@ const styles = StyleSheet.create({
         flex: 1,
         justifyContent: 'center',
         alignItems: 'center'
-    },
-    button: {
-        marginTop: 10,
-        width: 30,
-        height: 30,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        borderRadius: 6,
-        backgroundColor: 'lightblue'
     }
 })
 

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Alert, Text, Button, StyleSheet, TouchableOpacity, FlatList } from 'react-native';
+import { View, StyleSheet, FlatList } from 'react-native';
 import { ChatBoardItem, ChatMessage, BoardPost, MessageType } from '../types/chatBoard.type';
 import ChatMessageItem from '../components/chat/ChatMessageItem'
 import BoardPostItem from '../components/board/BoardPostItem';

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, StyleSheet, FlatList } from 'react-native';
 import { ChatBoardItem, ChatMessage, BoardPost, MessageType } from '../types/chatBoard.type';
-import ChatMessageItem from '../components/chat/ChatMessageItem'
+import ChatMessageItem from '../components/chat/ChatMessageItem';
 import BoardPostItem from '../components/board/BoardPostItem';
 
 // 예시 아이템

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { View, Alert, Text, Button, StyleSheet, TouchableOpacity, FlatList } from 'react-native';
 import { ChatBoardItem, ChatMessage, BoardPost, MessageType } from '../types/chatBoard.type';
+import ChatMessageItem from '../components/chat/ChatMessageItem'
+import BoardPostItem from '../components/board/BoardPostItem';
 
+// 예시 아이템
 const initItems: ChatBoardItem[] = [
     {
         id: '1',
@@ -20,6 +23,14 @@ const initItems: ChatBoardItem[] = [
         content: '- 타입 정의하기\n- 메인 화면 UI 잡기',
         createdAt: new Date().toISOString(),
     },
+    {
+        id: '3',
+        userId: '24',
+        type: 'chat',
+        bookMark: false,
+        text: '리액트 네이티브 공부하기',
+        createdAt: new Date().toISOString(),
+    },
 ]
 
 const MainScreen = () => {
@@ -32,11 +43,11 @@ const MainScreen = () => {
             <FlatList<ChatBoardItem> // 이 리스트는 ChatBoardItem 배열을 렌더링하는 컴포넌트 명시
                 data={items} // 리스트에 보일 데이터 배열
                 keyExtractor={item => item.id} // items 중 하나의 아이템의 고유 key를 뽑는 함수(item의 id를 key로 쓰겠다.)
-                renderItem={({item}) => {
-                    if(item.type == 'chat') {
-                        return <Text>채팅: {item.text}</Text>;
+                renderItem={({ item }) => {
+                    if (item.type == 'chat') {
+                        return <ChatMessageItem item={item} />;
                     }
-                    return <Text>게시글: {item.title}</Text>;
+                    return <BoardPostItem item={item} />;
                 }}
             />
         </View>

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,7 +1,8 @@
-import React, {useEffect, useState} from 'react';
-import {View, Alert, Text, Button, StyleSheet, TouchableOpacity} from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Alert, Text, Button, StyleSheet, TouchableOpacity } from 'react-native';
+import { ChatBoardItem, ChatMessage, BoardPost, MessageType } from '../types/chatBoard.type';
 
-const HomeScreen = () => {
+const MainScreen = () => {
     const [count, setCount] = useState<number>(0);
 
     const handleCount = () => {
@@ -18,7 +19,7 @@ const HomeScreen = () => {
         <View style={styles.container}>
             <Text>맴매 맞을 횟수: {count}</Text>
             <TouchableOpacity onPress={handleCount} style={styles.button}>
-                <Text>+</Text>    
+                <Text>+</Text>
             </TouchableOpacity>
         </View>
     )
@@ -42,4 +43,4 @@ const styles = StyleSheet.create({
     }
 })
 
-export default HomeScreen;
+export default MainScreen;

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -44,7 +44,7 @@ const MainScreen = () => {
                 data={items} // 리스트에 보일 데이터 배열
                 keyExtractor={item => item.id} // items 중 하나의 아이템의 고유 key를 뽑는 함수(item의 id를 key로 쓰겠다.)
                 renderItem={({ item }) => {
-                    if (item.type == 'chat') {
+                    if (item.type === 'chat') {
                         return <ChatMessageItem item={item} />;
                     }
                     return <BoardPostItem item={item} />;

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { View, StyleSheet, FlatList } from 'react-native';
 import { ChatBoardItem, MessageType } from '../types/chatBoard.type';
 import ChatMessageItem from '../components/chat/ChatMessageItem';

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, StyleSheet, FlatList } from 'react-native';
-import { ChatBoardItem, ChatMessage, BoardPost, MessageType } from '../types/chatBoard.type';
+import { ChatBoardItem, MessageType } from '../types/chatBoard.type';
 import ChatMessageItem from '../components/chat/ChatMessageItem';
 import BoardPostItem from '../components/board/BoardPostItem';
 

--- a/src/types/chatBoard.type.ts
+++ b/src/types/chatBoard.type.ts
@@ -1,0 +1,29 @@
+// 보낸 메시지가 채팅인지 게시물인지 타입으로 구분
+
+// 메시지 종류(채팅 chat이냐 게시물 post냐)
+export type MessageType = 'chat' | 'post';
+
+// 공통 필드 타입
+export interface BaseItem {
+    id: string;
+    type: MessageType; // 메시지 종류
+    createdAt: string; // 생성 날짜
+    isMe: boolean; // 내가 만든 것인가(추후 타인과 대화를 추가할 경우 대비)
+    bookMark: boolean; // 북마크 유무
+}
+
+// 채팅 메시지 타입
+export interface ChatMessage extends BaseItem {
+    type: 'chat'; // 채팅 메시지라 'chat'으로 고정
+    text: string; // 메시지 내용
+}
+
+// 게시판 글 타입
+export interface BoardPost extends BaseItem {
+    type: 'post';
+    title: string; // 제목
+    content: string; // 내용
+}
+
+// 메인 화면의 리스트에 들어갈 통합 아이템 타입
+export type ChatBoardItem = ChatMessage | BoardPost; // 아이템은 채팅이거나 게시물이거나

--- a/src/types/chatBoard.type.ts
+++ b/src/types/chatBoard.type.ts
@@ -6,9 +6,9 @@ export type MessageType = 'chat' | 'post';
 // 공통 필드 타입
 export interface BaseItem {
     id: string;
+    userId: string; // 누가 만든 것인가(추후 타인과 대화를 추가할 경우 대비)
     type: MessageType; // 메시지 종류
     createdAt: string; // 생성 날짜
-    isMe: boolean; // 내가 만든 것인가(추후 타인과 대화를 추가할 경우 대비)
     bookMark: boolean; // 북마크 유무
 }
 


### PR DESCRIPTION
### ✅ 작업 내용
- HomeScreen -> MainScreen으로 변경
- 채팅/게시물 타입 정의
- 메인페이지에 임의의 채팅/게시물 내용 표시 테스트 완료
- 채팅/게시물 컴포넌트 파일 분리

### 🐞 관련 이슈
- Closes: #13, #14

### 🛠 리뷰 & 실행 확인 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 리뷰어 지정 완료
- [ ] 코드 리뷰 승인 완료
- [x] 로컬에서 정상 실행 확인

### 📝 리뷰어 요청사항
- 채팅 또는 게시물에 대한 내용은 컴포넌트에서 확인

### 📸 스크린샷 (필요 시 첨부)
<img width="362" height="604" alt="image" src="https://github.com/user-attachments/assets/f94f8d26-9f40-40fd-bea7-ab918bd93675" />

<img width="364" height="747" alt="image" src="https://github.com/user-attachments/assets/e388fb37-0e7a-4bc4-ac33-7c08761ab9c6" />
