### PR TITLE
fix: 로그인 API 응답 구조 통일 및 refreshToken 지원

### DIFF
--- a/docs/devNote.txt
+++ b/docs/devNote.txt
@@ -7,6 +7,14 @@
 [릴리즈 빌드] Metro 불필요 (PC 연결 없이 독립 실행 가능)
   npm run android:release
 
+[캐시 지운 후 시작]
+Metro 캐시 (JavaScript):
+  npx react-native start --reset-cache
+
+Gradle 캐시 (Android 빌드):
+  rmdir /s /q android\.gradle
+  rmdir /s /q android\app\build
+
 -----
 <참고: Android 16 이슈>
 

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -101,9 +101,9 @@ const LoginScreen = () => {
         throw new Error(await parseErrorMessage(response));
       }
 
-      const data = await response.json();
-      const accessToken = data?.accessToken;
-      console.log('로그인 성공, 받은 토큰:', accessToken);
+      const apiResponse = await response.json();
+      const { accessToken, refreshToken, expiresIn } = apiResponse.data;
+      console.log('로그인 성공, 받은 토큰:', accessToken, 'expiresIn:', expiresIn);
 
       if (!accessToken) {
         throw new Error('토큰이 응답에 없습니다.');
@@ -119,6 +119,9 @@ const LoginScreen = () => {
 
       // AsyncStorage에 저장
       await AsyncStorage.setItem('accessToken', accessToken);
+      if (refreshToken) {
+        await AsyncStorage.setItem('refreshToken', refreshToken);
+      }
       await AsyncStorage.setItem('userId', userId);
       const autoLoginFlag = autoLogin ? 'true' : 'false';
       await AsyncStorage.setItem(STORAGE_KEYS.AUTO_LOGIN, autoLoginFlag);

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -29,6 +29,7 @@ const SettingsScreen = ({ navigation }: Props) => {
             // AsyncStorage에서 인증 정보 삭제
             await AsyncStorage.multiRemove([
               'accessToken',
+              'refreshToken',
               'userId',
               'AUTO_LOGIN',
             ]);

--- a/src/utils/tokenUtils.ts
+++ b/src/utils/tokenUtils.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const STORAGE_KEYS = {
   ACCESS_TOKEN: 'accessToken',
+  REFRESH_TOKEN: 'refreshToken',
   USER_ID: 'userId',
   AUTO_LOGIN: 'AUTO_LOGIN',
 };
@@ -76,10 +77,17 @@ export const isAutoLoginEnabled = async (): Promise<boolean> => {
 };
 
 /**
- * 저장된 토큰 조회
+ * 저장된 accessToken 조회
  */
 export const getStoredToken = async (): Promise<string | null> => {
   return AsyncStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
+};
+
+/**
+ * 저장된 refreshToken 조회
+ */
+export const getStoredRefreshToken = async (): Promise<string | null> => {
+  return AsyncStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
 };
 
 /**


### PR DESCRIPTION
### ✅ 작업 내용
- LoginScreen: API 응답을 apiResponse.data에서 추출
- refreshToken을 AsyncStorage에 저장 (expiresIn 로깅 추가)
- tokenUtils: REFRESH_TOKEN 상수, getStoredRefreshToken() 함수 추가
- SettingsScreen & auth: 로그아웃 시 refreshToken도 삭제
- docs: 캐시 제거 명령어 추가 (Metro, Gradle)

### 🛠 리뷰 & 실행 확인 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 리뷰어 지정 완료
- [ ] 코드 리뷰 승인 완료
- [x] 로컬에서 정상 실행 확인

### 📸 스크린샷 (필요 시 첨부)
아래 오류 해결
<img width="1440" height="2800" alt="image" src="https://github.com/user-attachments/assets/8b38ada0-5d30-45a5-96f5-a02c49ead167" />
