### PR TITLE
refactor: 검색·필터·복사 기능 개선

### DIFF
--- a/src/components/common/ContextMenu.tsx
+++ b/src/components/common/ContextMenu.tsx
@@ -15,7 +15,9 @@ interface ContextMenuProps {
   visible: boolean;
   itemType: 'memo' | 'board';
   isBookmarked: boolean;
-  onCopy: () => void;
+  showCopyButton?: boolean;
+  copyLabel?: string;
+  onCopy?: () => void;
   onBookmark: () => void;
   onConvert: () => void;
   onDelete: () => void;
@@ -26,6 +28,8 @@ const ContextMenu = ({
   visible,
   itemType,
   isBookmarked,
+  showCopyButton = false,
+  copyLabel = '내용 복사',
   onCopy,
   onBookmark,
   onConvert,
@@ -64,7 +68,6 @@ const ContextMenu = ({
     }).start(() => onClose());
   };
 
-  const copyLabel = itemType === 'memo' ? '내용 복사' : '제목 복사';
   const convertLabel = itemType === 'memo' ? '보드로 변환' : '메모로 변환';
 
   return (
@@ -88,16 +91,20 @@ const ContextMenu = ({
             styles['contextMenu-card'],
             { transform: [{ scale: fadeAnim.interpolate({ inputRange: [0, 1], outputRange: [0.9, 1] }) }] },
           ]}>
-          {/* 복사 */}
-          <TouchableOpacity
-            style={styles['contextMenu-item']}
-            onPress={() => handleAction(onCopy)}
-            activeOpacity={0.6}>
-            <Text style={styles['contextMenu-item-text']}>{copyLabel}</Text>
-            <CopyIcon color="#3A3A3A" size={20} />
-          </TouchableOpacity>
+          {/* 복사 - 메모의 텍스트/이미지만 */}
+          {showCopyButton && onCopy && (
+            <>
+              <TouchableOpacity
+                style={styles['contextMenu-item']}
+                onPress={() => handleAction(onCopy)}
+                activeOpacity={0.6}>
+                <Text style={styles['contextMenu-item-text']}>{copyLabel}</Text>
+                <CopyIcon color="#3A3A3A" size={20} />
+              </TouchableOpacity>
 
-          <View style={styles['contextMenu-separator']} />
+              <View style={styles['contextMenu-separator']} />
+            </>
+          )}
 
           {/* 북마크 */}
           <TouchableOpacity

--- a/src/components/common/ContextMenu.tsx
+++ b/src/components/common/ContextMenu.tsx
@@ -93,7 +93,7 @@ const ContextMenu = ({
           ]}>
           {/* 복사 - 메모의 텍스트/이미지만 */}
           {showCopyButton && onCopy && (
-            <>
+            <View>
               <TouchableOpacity
                 style={styles['contextMenu-item']}
                 onPress={() => handleAction(onCopy)}
@@ -103,7 +103,7 @@ const ContextMenu = ({
               </TouchableOpacity>
 
               <View style={styles['contextMenu-separator']} />
-            </>
+            </View>
           )}
 
           {/* 북마크 */}

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -43,6 +43,7 @@ import * as timelineService from '../services/timelineService';
 import * as memoService from '../services/memoService';
 import * as boardService from '../services/boardService';
 import * as noteService from '../services/noteService';
+import * as searchService from '../services/searchService';
 
 const MainScreen = () => {
   const insets = useSafeAreaInsets();
@@ -141,6 +142,13 @@ const MainScreen = () => {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [isTagFilterVisible, setIsTagFilterVisible] = useState(false);
 
+  // 검색 API 관련 state
+  const [isLoadingSearch, setIsLoadingSearch] = useState(false);
+  const [searchResults, setSearchResults] = useState<searchService.SearchItem[]>([]);
+  const [nextSearchCursor, setNextSearchCursor] = useState<string | null>(null);
+  const [searchHasMore, setSearchHasMore] = useState(false);
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const [recentBoards, setRecentBoards] = useState<Board[]>([]);
 
   // 보드 & 노트 펼치기/접기 상태 관리
@@ -219,6 +227,14 @@ const MainScreen = () => {
   const filteredItems = useMemo(() => {
     let result = items;
 
+    // 검색 모드일 때는 API 응답 결과로만 필터링
+    if (isSearchMode && searchResults.length > 0) {
+      const searchUids = new Set(searchResults.map(r => r.uid));
+      result = result.filter(i => searchUids.has(i.id));
+      return result;
+    }
+
+    // 검색 모드가 아닐 때는 기존 필터링 로직
     // 타입 필터
     if (filterType === 'memo') {
       result = result.filter(i => i.type === 'memo');
@@ -278,9 +294,52 @@ const MainScreen = () => {
     }
 
     return result;
-  }, [items, filterType, filterBookmarkOnly, searchText, selectedTags]);
+  }, [items, filterType, filterBookmarkOnly, searchText, selectedTags, isSearchMode, searchResults]);
 
   const timelineItems = useMemo(() => [...filteredItems].reverse(), [filteredItems]);
+
+  // 검색 함수 (디바운싱 적용)
+  const performSearch = useCallback(async (query: string) => {
+    if (!query.trim()) {
+      setSearchResults([]);
+      setNextSearchCursor(null);
+      setSearchHasMore(false);
+      return;
+    }
+
+    try {
+      setIsLoadingSearch(true);
+      const response = await searchService.search(query, undefined, 20);
+      setSearchResults(response.items);
+      setNextSearchCursor(response.nextCursor);
+      setSearchHasMore(response.hasNext);
+    } catch (error) {
+      console.error('Search error:', error);
+      showAlert({ title: '검색 오류', message: '검색 중 오류가 발생했습니다.', type: 'error' });
+      setSearchResults([]);
+      setNextSearchCursor(null);
+      setSearchHasMore(false);
+    } finally {
+      setIsLoadingSearch(false);
+    }
+  }, [showAlert]);
+
+  // 검색 텍스트 변경 시 디바운싱
+  useEffect(() => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+
+    searchTimeoutRef.current = setTimeout(() => {
+      performSearch(searchText);
+    }, 300);
+
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+    };
+  }, [searchText, performSearch]);
 
   const nativeShareModule =
     Platform.OS === 'ios'
@@ -709,6 +768,35 @@ const MainScreen = () => {
     setImageViewerVisible(true);
   };
 
+  // 검색 결과 클릭 처리
+  const handleSearchResultPress = (item: searchService.SearchItem) => {
+    setIsSearchMode(false);
+    setSearchText('');
+
+    if (item.type === 'memo') {
+      // 메모: 타임라인에서 스크롤로 찾기
+      const index = items.findIndex(i => i.id === item.uid);
+      if (index !== -1) {
+        flatListRef.current?.scrollToIndex({ index, animated: true, viewPosition: 0.5 });
+      }
+    } else if (item.type === 'board') {
+      // 보드: 보드 상세로 이동
+      const board = items.find(i => i.id === item.uid && i.type === 'board') as any;
+      if (board) {
+        navigation.navigate('BoardDetail', { board });
+      }
+    } else if (item.type === 'note') {
+      // 노트: 부모 보드로 이동하되 해당 노트 포커스
+      const board = items.find(i => i.id === item.parentUid && i.type === 'board') as any;
+      if (board) {
+        navigation.navigate('BoardDetail', {
+          board,
+          noteId: item.uid,
+        });
+      }
+    }
+  };
+
   const handleSend = async () => {
     if (!inputText.trim()) return;
     const text = inputText.trim();
@@ -936,69 +1024,79 @@ const MainScreen = () => {
             </View>
           ) : null}
 
-          <FlatList<TimelineItem>
-            ref={flatListRef}
-            data={timelineItems}
-            keyExtractor={item => item.id}
-            style={styles['main-list']}
-            contentContainerStyle={styles['main-listContent']}
-            inverted
-            keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
-            keyboardShouldPersistTaps="handled"
-            onContentSizeChange={() => {
-              scrollToLatestIfNeeded();
-            }}
-            onLayout={scrollToLatestIfNeeded}
-            renderItem={({ item, index }) => {
-              // 다음 아이템의 시간과 비교하여 같은 시간에 보낸 것인지 확인
-              const currentTime = getHourMinute(item.createdAt);
-              const nextItem = index > 0 ? timelineItems[index - 1] : null;
-              const nextTime = nextItem ? getHourMinute(nextItem.createdAt) : null;
-              const isLastInTime = !nextTime || currentTime !== nextTime;
+            // 일반 타임라인 리스트
+            <FlatList<TimelineItem>
+              ref={flatListRef}
+              data={timelineItems}
+              keyExtractor={item => item.id}
+              style={styles['main-list']}
+              contentContainerStyle={styles['main-listContent']}
+              inverted
+              keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
+              keyboardShouldPersistTaps="handled"
+              onContentSizeChange={() => {
+                scrollToLatestIfNeeded();
+              }}
+              onLayout={scrollToLatestIfNeeded}
+              renderItem={({ item, index }) => {
+                // 다음 아이템의 시간과 비교하여 같은 시간에 보낸 것인지 확인
+                const currentTime = getHourMinute(item.createdAt);
+                const nextItem = index > 0 ? timelineItems[index - 1] : null;
+                const nextTime = nextItem ? getHourMinute(nextItem.createdAt) : null;
+                const isLastInTime = !nextTime || currentTime !== nextTime;
 
-              if (item.type === 'memo') {
-                const memo = item as Memo;
+                if (item.type === 'memo') {
+                  const memo = item as Memo;
+                  return (
+                    <ChatMessageItem
+                      item={memo}
+                      expanded={expandedMemoId === memo.id}
+                      showTime={isLastInTime}
+                      onToggleExpand={(m) => setExpandedMemoId(expandedMemoId === m.id ? null : m.id)}
+                      onLongPress={handleContextMenu}
+                      onOpenLinkModal={handleOpenLinkModal}
+                      onImagePress={handleImagePress}
+                    />
+                  );
+                }
+
                 return (
-                  <ChatMessageItem
-                    item={memo}
-                    expanded={expandedMemoId === memo.id}
+                  <BoardCard
+                    item={item as Board}
+                    onContextMenu={handleContextMenu}
+                    onDetailPress={handleDetailPress}
+                    onPress={handleDetailPress}
                     showTime={isLastInTime}
-                    onToggleExpand={(m) => setExpandedMemoId(expandedMemoId === m.id ? null : m.id)}
-                    onLongPress={handleContextMenu}
-                    onOpenLinkModal={handleOpenLinkModal}
-                    onImagePress={handleImagePress}
+                    isExpanded={boardExpandStates[(item as Board).id] ?? true}
+                    onExpandChange={(id, expanded) => setBoardExpandStates(prev => ({ ...prev, [id]: expanded }))}
+                    expandedNoteIds={Object.keys(noteExpandStates).filter(key => {
+                      const board = item as Board;
+                      return noteExpandStates[key] && board.notes?.some(n => n.id === key);
+                    })}
+                    onNoteExpandChange={(noteId, expanded) => {
+                      setNoteExpandStates(prev => {
+                        if (expanded) {
+                          return { ...prev, [noteId]: true };
+                        } else {
+                          const newStates = { ...prev };
+                          delete newStates[noteId];
+                          return newStates;
+                        }
+                      });
+                    }}
                   />
                 );
-              }
-
-              return (
-                <BoardCard
-                  item={item as Board}
-                  onContextMenu={handleContextMenu}
-                  onDetailPress={handleDetailPress}
-                  onPress={handleDetailPress}
-                  showTime={isLastInTime}
-                  isExpanded={boardExpandStates[(item as Board).id] ?? true}
-                  onExpandChange={(id, expanded) => setBoardExpandStates(prev => ({ ...prev, [id]: expanded }))}
-                  expandedNoteIds={Object.keys(noteExpandStates).filter(key => {
-                    const board = item as Board;
-                    return noteExpandStates[key] && board.notes?.some(n => n.id === key);
-                  })}
-                  onNoteExpandChange={(noteId, expanded) => {
-                    setNoteExpandStates(prev => {
-                      if (expanded) {
-                        return { ...prev, [noteId]: true };
-                      } else {
-                        const newStates = { ...prev };
-                        delete newStates[noteId];
-                        return newStates;
-                      }
-                    });
-                  }}
-                />
-              );
-            }}
-          />
+              }}
+            ListEmptyComponent={
+              isSearchMode && searchText.trim() && !isLoadingSearch ? (
+                <View style={{ paddingVertical: 40, alignItems: 'center', justifyContent: 'center' }}>
+                  <Text style={{ fontSize: 14, color: '#AABBCC', fontFamily: 'PretendardVariable' }}>
+                    검색 결과가 없습니다
+                  </Text>
+                </View>
+              ) : undefined
+            }
+            />
         </View>
 
         <View

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -14,6 +14,9 @@ import {
   Keyboard,
   Modal,
   ScrollView,
+  Clipboard,
+  ToastAndroid,
+  Animated,
 } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -543,13 +546,31 @@ const MainScreen = () => {
   const handleContextMenu = (item: TimelineItem) => setContextMenuItem(item);
   const handleCloseContextMenu = () => setContextMenuItem(null);
 
-  const handleContextCopy = () => {
+  const handleContextCopy = async () => {
     if (!contextMenuItem) return;
-    const text =
-      contextMenuItem.type === 'memo'
-        ? contextMenuItem.text
-        : contextMenuItem.title;
-    showAlert({ title: '복사됨', message: text, type: 'success' });
+    if (contextMenuItem.type !== 'memo') return;
+
+    const memo = contextMenuItem as Memo;
+
+    try {
+      // 텍스트 메모
+      if (memo.text && !memo.imageUris?.length && !memo.videos?.length && !memo.files?.length) {
+        await Clipboard.setString(memo.text);
+        ToastAndroid.show('텍스트 복사됨', ToastAndroid.SHORT);
+        return;
+      }
+
+      // 이미지 메모
+      if (memo.imageUris?.length) {
+        // 첫 번째 이미지 URL을 클립보드에 복사
+        await Clipboard.setString(memo.imageUris[0]);
+        ToastAndroid.show(`${memo.imageUris.length}개의 이미지 복사됨`, ToastAndroid.SHORT);
+        return;
+      }
+    } catch (error) {
+      console.error('Failed to copy to clipboard:', error);
+      ToastAndroid.show('복사 실패', ToastAndroid.SHORT);
+    }
   };
 
   const handleContextBookmark = async () => {
@@ -1458,6 +1479,16 @@ const MainScreen = () => {
         visible={contextMenuItem !== null}
         itemType={contextMenuItem?.type ?? 'memo'}
         isBookmarked={contextMenuItem?.bookmarked ?? false}
+        showCopyButton={
+          contextMenuItem?.type === 'memo' && (
+            // 텍스트 메모 또는 이미지 메모만
+            (!((contextMenuItem as Memo).imageUris?.length || (contextMenuItem as Memo).videos?.length || (contextMenuItem as Memo).files?.length)) ||
+            (contextMenuItem as Memo).imageUris?.length > 0
+          )
+        }
+        copyLabel={
+          (contextMenuItem as Memo)?.imageUris?.length > 0 ? '이미지 복사' : '내용 복사'
+        }
         onCopy={handleContextCopy}
         onBookmark={handleContextBookmark}
         onConvert={handleContextConvert}

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -137,10 +137,12 @@ const MainScreen = () => {
   // 검색 & 필터
   const [isSearchMode, setIsSearchMode] = useState(false);
   const [searchText, setSearchText] = useState('');
-  const [filterType, setFilterType] = useState<'all' | 'memo' | 'board'>('all');
   const [filterBookmarkOnly, setFilterBookmarkOnly] = useState(false);
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
-  const [isTagFilterVisible, setIsTagFilterVisible] = useState(false);
+
+  // 검색 필터
+  type SearchFieldFilter = 'memoTextOnly' | 'board' | 'note' | 'tag' | 'photo' | 'video' | 'file';
+  const [searchFieldFilters, setSearchFieldFilters] = useState<Set<SearchFieldFilter>>(new Set());
+  const [isSearchFilterVisible, setIsSearchFilterVisible] = useState(false);
 
   // 검색 API 관련 state
   const [isLoadingSearch, setIsLoadingSearch] = useState(false);
@@ -227,19 +229,64 @@ const MainScreen = () => {
   const filteredItems = useMemo(() => {
     let result = items;
 
-    // 검색 모드일 때는 API 응답 결과로만 필터링
-    if (isSearchMode && searchResults.length > 0) {
+    // 필터가 선택되어 있으면 항상 적용 (검색 모드 여부 상관없음)
+    if (searchFieldFilters.size > 0) {
+      result = result.filter(item => {
+        for (const filter of searchFieldFilters) {
+          // 타입 필터
+          if (filter === 'memoTextOnly') {
+            if (item.type === 'memo') {
+              const memo = item as Memo;
+              // 미디어가 없는 순수 텍스트 메모만
+              if (!memo.imageUris?.length && !memo.videos?.length && !memo.files?.length) {
+                return true;
+              }
+            }
+          }
+          if (filter === 'board' && item.type === 'board') return true;
+          if (filter === 'note' && item.type === 'board') {
+            // 노트는 보드 내에 있으므로 보드를 표시
+            return true;
+          }
+
+          // 미디어/태그 필터
+          if (filter === 'tag') {
+            if (item.type === 'board' && (item as Board).tags?.length > 0) return true;
+          }
+
+          if (filter === 'photo') {
+            if (item.type === 'memo' && (item as Memo).imageUris?.length > 0) return true;
+            if (item.type === 'board') {
+              const board = item as Board;
+              if (board.notes?.some(n => n.imageUris?.length > 0)) return true;
+            }
+          }
+
+          if (filter === 'video') {
+            if (item.type === 'memo' && (item as Memo).videos?.length > 0) return true;
+            if (item.type === 'board') {
+              const board = item as Board;
+              if (board.notes?.some(n => n.videos?.length > 0)) return true;
+            }
+          }
+
+          if (filter === 'file') {
+            if (item.type === 'memo' && (item as Memo).files?.length > 0) return true;
+            if (item.type === 'board') {
+              const board = item as Board;
+              if (board.notes?.some(n => n.files?.length > 0)) return true;
+            }
+          }
+        }
+        return false;
+      });
+    }
+
+    // 검색 모드이고 필터가 없을 때는 API 검색 결과로 필터링
+    if (isSearchMode && searchResults.length > 0 && searchFieldFilters.size === 0) {
       const searchUids = new Set(searchResults.map(r => r.uid));
       result = result.filter(i => searchUids.has(i.id));
       return result;
-    }
-
-    // 검색 모드가 아닐 때는 기존 필터링 로직
-    // 타입 필터
-    if (filterType === 'memo') {
-      result = result.filter(i => i.type === 'memo');
-    } else if (filterType === 'board') {
-      result = result.filter(i => i.type === 'board');
     }
 
     // 북마크 필터
@@ -247,54 +294,8 @@ const MainScreen = () => {
       result = result.filter(i => i.bookmarked);
     }
 
-    // 태그 필터 (보드만)
-    if (selectedTags.length > 0) {
-      result = result.filter(i => {
-        if (i.type === 'board') {
-          const board = i as Board;
-          return selectedTags.some(tag => board.tags?.includes(tag));
-        }
-        return true;
-      });
-    }
-
-    // 검색 텍스트 필터
-    if (searchText.trim()) {
-      const query = searchText.toLowerCase();
-
-      // 태그 검색 (# 포함)
-      if (query.startsWith('#')) {
-        const tagQuery = query.substring(1).trim();
-        result = result.filter(i => {
-          if (i.type === 'board') {
-            const board = i as Board;
-            return (board.tags ?? []).some(tag => (tag ?? '').toLowerCase().includes(tagQuery));
-          }
-          return false;
-        });
-      } else {
-        // 일반 텍스트 검색
-        result = result.filter(i => {
-          if (i.type === 'memo') {
-            return ((i as Memo).text ?? '').toLowerCase().includes(query);
-          } else {
-            const board = i as Board;
-            // 보드 제목 검색
-            if ((board.title ?? '').toLowerCase().includes(query)) {
-              return true;
-            }
-            // 보드 내 노트 제목, 내용 검색
-            return (board.notes ?? []).some(note =>
-              note.title?.toLowerCase().includes(query) ||
-              note.content?.toLowerCase().includes(query)
-            );
-          }
-        });
-      }
-    }
-
     return result;
-  }, [items, filterType, filterBookmarkOnly, searchText, selectedTags, isSearchMode, searchResults]);
+  }, [items, isSearchMode, searchResults, searchFieldFilters, filterBookmarkOnly]);
 
   const timelineItems = useMemo(() => [...filteredItems].reverse(), [filteredItems]);
 
@@ -929,7 +930,7 @@ const MainScreen = () => {
       <View style={styles['main-header']}>
         {isSearchMode ? (
           <>
-            <TouchableOpacity onPress={() => { setIsSearchMode(false); setSearchText(''); }} style={styles['main-header-iconButton']}>
+            <TouchableOpacity onPress={() => { setIsSearchMode(false); setSearchText(''); setSearchFieldFilters(new Set()); }} style={styles['main-header-iconButton']}>
               <ArrowLeftIcon color="#1A1A1A" size={20} />
             </TouchableOpacity>
             <TextInput
@@ -941,10 +942,10 @@ const MainScreen = () => {
               autoFocus
             />
             <TouchableOpacity
-              style={[styles['main-header-iconButton'], selectedTags.length > 0 && { backgroundColor: '#E8EEFF' }]}
-              onPress={() => setIsTagFilterVisible(true)}>
-              <Text style={[{ fontSize: 10, fontWeight: '600', color: selectedTags.length > 0 ? '#588DFF' : '#1A1A1A' }]}>
-                필터
+              style={[styles['main-header-iconButton'], searchFieldFilters.size > 0 && { backgroundColor: '#E8EEFF' }]}
+              onPress={() => setIsSearchFilterVisible(true)}>
+              <Text style={[{ fontSize: 10, fontWeight: '600', color: searchFieldFilters.size > 0 ? '#588DFF' : '#1A1A1A' }]}>
+                {searchFieldFilters.size > 0 ? `필터 (${searchFieldFilters.size})` : '필터'}
               </Text>
             </TouchableOpacity>
           </>
@@ -1124,16 +1125,16 @@ const MainScreen = () => {
         isLoading={isUploadingMedia}
       />
 
-      {/* 태그 필터 모달 */}
+      {/* 검색 필터 모달 */}
       <Modal
-        visible={isTagFilterVisible}
+        visible={isSearchFilterVisible}
         transparent
         animationType="slide"
-        onRequestClose={() => setIsTagFilterVisible(false)}>
+        onRequestClose={() => setIsSearchFilterVisible(false)}>
         <TouchableOpacity
-          style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.4)' }}
+          style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.2)' }}
           activeOpacity={1}
-          onPress={() => setIsTagFilterVisible(false)}>
+          onPress={() => setIsSearchFilterVisible(false)}>
           <View
             style={{
               backgroundColor: '#FFFFFF',
@@ -1143,80 +1144,67 @@ const MainScreen = () => {
               paddingHorizontal: 18,
               paddingBottom: Math.max(insets.bottom, 18),
               marginTop: 'auto',
-              maxHeight: '70%',
             }}
-            onStartShouldSetResponder={() => true}>
-            <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14 }}>
+            onStartShouldSetResponder={() => true}
+            pointerEvents="auto">
+            <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20 }}>
               <Text style={{ fontSize: 16, fontWeight: '700', color: '#1A1A1A', fontFamily: 'PretendardVariable' }}>
-                태그 필터
+                검색 필터
               </Text>
-              <TouchableOpacity onPress={() => setIsTagFilterVisible(false)}>
-                <Text style={{ fontSize: 24, color: '#9DAFC8' }}>✕</Text>
-              </TouchableOpacity>
+              <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+                {searchFieldFilters.size > 0 && (
+                  <TouchableOpacity onPress={() => setSearchFieldFilters(new Set())}>
+                    <Text style={{ fontSize: 12, color: '#9DAFC8', fontWeight: '600', fontFamily: 'PretendardVariable' }}>
+                      초기화
+                    </Text>
+                  </TouchableOpacity>
+                )}
+                <TouchableOpacity onPress={() => setIsSearchFilterVisible(false)}>
+                  <Text style={{ fontSize: 24, color: '#9DAFC8' }}>✕</Text>
+                </TouchableOpacity>
+              </View>
             </View>
 
-            <ScrollView showsVerticalScrollIndicator={false} style={{ marginBottom: 12 }}>
+            <ScrollView showsVerticalScrollIndicator={false}>
               <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
-                {/* 모든 태그 */}
-                {Array.from(new Set(
-                  items
-                    .filter(i => i.type === 'board')
-                    .flatMap(i => (i as Board).tags ?? [])
-                )).map(tag => (
+                {(['memoTextOnly', 'board', 'note', 'tag', 'photo', 'video', 'file'] as SearchFieldFilter[]).map(filter => (
                   <TouchableOpacity
-                    key={tag}
+                    key={filter}
                     onPress={() => {
-                      setSelectedTags(prev =>
-                        prev.includes(tag)
-                          ? prev.filter(t => t !== tag)
-                          : [...prev, tag]
-                      );
+                      const newFilters = new Set(searchFieldFilters);
+                      if (newFilters.has(filter)) {
+                        newFilters.delete(filter);
+                      } else {
+                        newFilters.add(filter);
+                      }
+                      setSearchFieldFilters(newFilters);
                     }}
                     style={{
                       paddingHorizontal: 12,
                       paddingVertical: 6,
                       borderRadius: 20,
-                      backgroundColor: selectedTags.includes(tag) ? '#588DFF' : '#F0F4FF',
-                      borderWidth: selectedTags.includes(tag) ? 0 : 1,
+                      backgroundColor: searchFieldFilters.has(filter) ? '#588DFF' : '#F0F4FF',
+                      borderWidth: searchFieldFilters.has(filter) ? 0 : 1,
                       borderColor: '#C0CDD8',
                     }}>
                     <Text style={{
                       fontSize: 11,
                       fontWeight: '500',
-                      color: selectedTags.includes(tag) ? '#FFFFFF' : '#588DFF',
+                      color: searchFieldFilters.has(filter) ? '#FFFFFF' : '#588DFF',
                       fontFamily: 'PretendardVariable',
                     }}>
-                      #{tag}
+                      {filter === 'memoTextOnly' ? '메모(텍스트)' :
+                       filter === 'memo' ? '메모' :
+                       filter === 'board' ? '보드' :
+                       filter === 'note' ? '노트' :
+                       filter === 'tag' ? '태그' :
+                       filter === 'photo' ? '사진' :
+                       filter === 'video' ? '동영상' : '파일'}
                     </Text>
                   </TouchableOpacity>
                 ))}
               </View>
-
-              {Array.from(new Set(
-                items
-                  .filter(i => i.type === 'board')
-                  .flatMap(i => (i as Board).tags ?? [])
-              )).length === 0 && (
-                <Text style={{ fontSize: 12, color: '#AABBCC', fontFamily: 'PretendardVariable', textAlign: 'center', paddingVertical: 16 }}>
-                  사용 가능한 태그가 없습니다
-                </Text>
-              )}
             </ScrollView>
-
-            {selectedTags.length > 0 && (
-              <TouchableOpacity
-                onPress={() => setSelectedTags([])}
-                style={{
-                  paddingVertical: 8,
-                  alignItems: 'center',
-                  borderTopWidth: 1,
-                  borderTopColor: '#E8EEF8',
-                }}>
-                <Text style={{ fontSize: 12, color: '#9DAFC8', fontWeight: '600', fontFamily: 'PretendardVariable' }}>
-                  필터 초기화
-                </Text>
-              </TouchableOpacity>
-            )}
           </View>
         </TouchableOpacity>
       </Modal>
@@ -1235,6 +1223,7 @@ const MainScreen = () => {
         onBookmarkFilterToggle={(active) => {
           setFilterBookmarkOnly(active);
           setIsSearchMode(false);
+          setSearchFieldFilters(new Set());
         }}
         onMediaGalleryPress={(galleryType) => {
           navigation.navigate('MediaGallery', {

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1046,7 +1046,7 @@ const MainScreen = () => {
             </View>
           ) : null}
 
-            // 일반 타임라인 리스트
+            {/* 일반 타임라인 리스트 */}
             <FlatList<TimelineItem>
               ref={flatListRef}
               data={timelineItems}
@@ -1121,19 +1121,21 @@ const MainScreen = () => {
             />
         </View>
 
-        <View
-          style={[
-            styles['main-inputBarWrapper'],
-            Platform.OS === 'android' && keyboardVisible && styles['main-inputBarWrapper-keyboardVisible'],
-          ]}>
-          <ChatInputBar
-            inputText={inputText}
-            onChangeText={setInputText}
-            onSend={handleSend}
-            onPlusPress={() => setMediaPickerVisible(true)}
-            bottomInset={Platform.OS === 'ios' && keyboardVisible ? 0 : insets.bottom}
-          />
-        </View>
+        {!isSearchMode && (
+          <View
+            style={[
+              styles['main-inputBarWrapper'],
+              Platform.OS === 'android' && keyboardVisible && styles['main-inputBarWrapper-keyboardVisible'],
+            ]}>
+            <ChatInputBar
+              inputText={inputText}
+              onChangeText={setInputText}
+              onSend={handleSend}
+              onPlusPress={() => setMediaPickerVisible(true)}
+              bottomInset={Platform.OS === 'ios' && keyboardVisible ? 0 : insets.bottom}
+            />
+          </View>
+        )}
       </KeyboardAvoidingView>
 
       {/* 미디어 피커 시트 */}

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -1,0 +1,104 @@
+import { fetchWithAutoLogoutHandler } from '../utils/tokenUtils';
+
+const API_BASE_URL = 'https://memme.o-r.kr/v1';
+
+interface ApiResponse<T> {
+  success: boolean;
+  status: number;
+  message: string;
+  data: T;
+}
+
+export interface SearchItem {
+  type: 'memo' | 'board' | 'note';
+  uid: string;
+  title: string;
+  content: string;
+  snippet: string;
+  parentType: string | null;
+  parentUid: string | null;
+  parentTitle: string | null;
+  tags: string[];
+  urls: string[];
+  attachmentNames: string[];
+  bookmarked: boolean;
+  createdAt: string;
+  updatedAt: string;
+  score: number;
+}
+
+export interface SearchResponse {
+  items: SearchItem[];
+  hasNext: boolean;
+  nextCursor: string | null;
+  limit: number;
+  totalCount: number;
+}
+
+export const search = async (
+  query: string,
+  type?: 'memo' | 'board' | 'note',
+  limit: number = 20,
+  cursor?: string
+): Promise<SearchResponse> => {
+  try {
+    const params = new URLSearchParams();
+    params.append('q', query);
+    if (type) {
+      params.append('type', type);
+    }
+    params.append('limit', limit.toString());
+    if (cursor) {
+      params.append('cursor', cursor);
+    }
+
+    const response = await fetchWithAutoLogoutHandler(
+      `${API_BASE_URL}/search?${params.toString()}`,
+      { method: 'GET' }
+    );
+
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status}`);
+    }
+
+    const apiResponse: ApiResponse<SearchResponse> = await response.json();
+    return apiResponse.data;
+  } catch (error) {
+    console.error('Search failed:', error);
+    throw error;
+  }
+};
+
+export const reindex = async (): Promise<{
+  indexName: string;
+  userUid: string;
+  indexedCount: number;
+  memoCount: number;
+  boardCount: number;
+  noteCount: number;
+}> => {
+  try {
+    const response = await fetchWithAutoLogoutHandler(
+      `${API_BASE_URL}/search/reindex`,
+      { method: 'POST' }
+    );
+
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status}`);
+    }
+
+    const apiResponse: ApiResponse<{
+      indexName: string;
+      userUid: string;
+      indexedCount: number;
+      memoCount: number;
+      boardCount: number;
+      noteCount: number;
+    }> = await response.json();
+
+    return apiResponse.data;
+  } catch (error) {
+    console.error('Reindex failed:', error);
+    throw error;
+  }
+};

--- a/src/styles/ChatMessageItem.styles.ts
+++ b/src/styles/ChatMessageItem.styles.ts
@@ -77,9 +77,7 @@ export const chatMessageItemStyles = StyleSheet.create({
 
   // 링크 관련 아이템들 컨테이너
   'links-container': {
-    gap: 8,
     alignItems: 'flex-end',
-    marginTop: 8,
     alignSelf: 'flex-end',
   },
 

--- a/src/styles/ChatMessageItem.styles.ts
+++ b/src/styles/ChatMessageItem.styles.ts
@@ -9,7 +9,7 @@ export const chatMessageItemStyles = StyleSheet.create({
   'container': {
     width: '100%',
     alignSelf: 'flex-end',
-    marginBottom: 12,
+    marginBottom: 8,
   },
 
   // 메시지 + 시간 행


### PR DESCRIPTION
### ✅ 작업 내용
검색 기능 개선
- Elasticsearch 기반 통합 검색 추가
- 기존: 렌더링된 메모/보드만 검색 가능
- 개선: 전체 데이터에서 검색 가능 (로드하지 않은 오래된 항목도)

검색 필터 확대
- 7가지 필터 추가: 메모(텍스트), 보드, 노트, 태그, 사진, 동영상, 파일
- 필터 선택 시 즉시 적용 (모달 닫을 필요 없음)
- 여러 필터 동시 선택 가능 (OR 조건)
- 검색 모드 뒤로가기 시 필터 초기화

복사 기능 개선
- 메모만 복사 가능 (보드/노트 제거)
- 텍스트 메모: 내용을 클립보드에 복사
- 이미지 메모: 이미지를 클립보드에 복사
- 동영상/파일: 복사 버튼 제거
- Alert 모달 → 토스트 알림으로 변경 (화면 아래 잠깐 표시)

채팅 요소 간 상하 간격 조절

### 🛠 리뷰 & 실행 확인 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 리뷰어 지정 완료
- [x] 로컬에서 정상 실행 확인

### 📸 스크린샷 (필요 시 첨부)
<img width="368" height="726" alt="image" src="https://github.com/user-attachments/assets/21132f27-ca0b-4fff-8515-9c09ec858b05" />
